### PR TITLE
MojoX::JSON::RPC::Client->call: fix setting content type on post

### DIFF
--- a/lib/MojoX/JSON/RPC/Client.pm
+++ b/lib/MojoX/JSON/RPC/Client.pm
@@ -29,7 +29,7 @@ sub call {
         if ( $body ne q{} ) {
             return $self->_process_result(
                 $self->ua->post(
-                    $uri, { Content_Type => $self->content_type }, $body
+                    $uri, { 'Content-Type' => $self->content_type }, $body
                 )
             );
         }
@@ -41,7 +41,7 @@ sub call {
         if ( $body ne q{} ) {
             $self->ua->post(
                 $uri,
-                { Content_Type => $self->content_type },
+                { 'Content-Type' => $self->content_type },
                 $body,
                 sub {    # callback
                     $callback->( $self->_process_result(pop) );


### PR DESCRIPTION
This seems a typo, cf
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type